### PR TITLE
Generate type declarations on build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.1",
   "description": "",
   "main": "dist/teller-connect-react.cjs.js",
+  "types": "dist/@types/index.d.ts",
   "scripts": {
     "build": "webpack --mode production",
+    "postbuild": "tsc -p tsconfig.types.json",
     "test": "NODE_ENV=test BABEL_ENV=testing jest"
   },
   "keywords": [],

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationDir": "./dist/@types",
+    "skipLibCheck": true
+  },
+  "exclude": [
+    "node_modules",
+    "examples",
+    "src/**/*.test.tsx",
+    "src/**/*.test.ts"
+  ]
+}


### PR DESCRIPTION
At the moment the project only outputs JavaScript code and the `"types"` property isn't specified in the `package.json` as well. Trying to import the package will result in:

```
Could not find a declaration file for module 'teller-connect-react'. '/redacted/node_modules/teller-connect-react/dist/teller-connect-react.cjs.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/teller-connect-react` if it exists or add a new declaration (.d.ts) file containing `declare module 'teller-connect-react';`
```

This PR adds generation of type declarations at compile time by using the `postbuild` lifecycle script, leaving the build process unchanged. I also updated `package.json` to point to the newly generated type declarations