### PR TITLE
Improve type declarations

### DIFF
--- a/src/TellerConnect.tsx
+++ b/src/TellerConnect.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
-import { TellerConnectPropTypes } from './types';
+import { TellerConnectOptions } from './types';
 import { useTellerConnect } from './useTellerConnect';
 
-export const TellerConnect: React.FC<TellerConnectPropTypes> = props => {
-  const { children, style, className, ...config } = props;
-  const { error, open } = useTellerConnect({ ...config });
+type PropTypes = TellerConnectOptions & React.HTMLProps<HTMLButtonElement>
+
+export const TellerConnect: React.FC<PropTypes> = ({ children, className, style, ...opts }) => {
+  const { error, open } = useTellerConnect({ ...opts });
 
   return (
     <button
-      disabled={Boolean(error)}
+      disabled={!!error}
       type="button"
       className={className}
       style={{

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { useTellerConnect } from './useTellerConnect';
 export { TellerConnect } from './TellerConnect';
-export * from './types'
+export * from './types';

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -3,11 +3,6 @@ import {
   TellerConnectInstance,
 } from './types';
 
-export interface TellerConnectManager {
-  open: (() => void) | Function;
-  destroy: (() => void) | Function;
-}
-
 interface ManagerState {
   teller: TellerConnectInstance | null;
   open: boolean;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,7 +52,7 @@ export interface TellerConnectOptions {
 
   // Undocumented options
   appearance?: "dark" | "light" | "system";
-  products?: ("identity" | "verify" | "transactions")[];
+  products?: ("balance" | "identity" | "transactions" | "verify")[];
   accountFilter?: object;
   onEvent?: TellerConnectOnEvent;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ export interface TellerConnectFailure {
 
 export type TellerConnectOnSuccess = (enrollment: TellerConnectEnrollment) => void;
 
-export type TellerConnectOnLoad = () => void;
+export type TellerConnectOnInit = () => void;
 
 export type TellerConnectOnExit = () => void;
 
@@ -46,7 +46,7 @@ export interface TellerConnectOptions {
   enrollmentId?: string;
   connectToken?: string;
   nonce?: string;
-  onInit?: TellerConnectOnLoad;
+  onInit?: TellerConnectOnInit;
   onExit?: TellerConnectOnExit;
   onFailure?: TellerConnectOnFailure;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,9 @@
-import React from 'react';
-import { TellerConnectManager } from '../manager';
+export interface TellerUser {
+  id: string;
+}
 
 export interface TellerInstitution {
   name: string;
-}
-
-export interface TellerUser {
-  id: string;
 }
 
 export interface TellerEnrollment {
@@ -18,48 +15,46 @@ export interface TellerConnectEnrollment {
   accessToken: string;
   user: TellerUser;
   enrollment: TellerEnrollment;
-  signatures: Array<string> | null;
-} 
-
-export interface TellerConnectOnEventMetadata {
+  signatures?: string[];
 }
 
-export type TellerConnectOnFailure = (failure: {
-  type: "payment" | "payee" | string;
-  code: "timeout" | "error" | string;
+export interface TellerConnectFailure {
+  type: "payee" | "payment";
+  code: "timeout" | "error";
   message: string;
-}) => void;
+}
+
+export type TellerConnectOnSuccess = (enrollment: TellerConnectEnrollment) => void;
 
 export type TellerConnectOnLoad = () => void;
 
 export type TellerConnectOnExit = () => void;
 
-export type TellerConnectOnSuccess = (
-  authorization: TellerConnectEnrollment
-) => void;
+export type TellerConnectOnFailure = (failure: TellerConnectFailure) => void;
 
-export type TellerConnectOnEvent = (
-  name: string,
-  data: object, 
-) => void;
+export type TellerConnectOnEvent = (name: string, data: object) => void;
 
 export interface TellerConnectOptions {
-  onSuccess: TellerConnectOnSuccess;
-  onLoad: null | TellerConnectOnLoad;
-  onFailure: null | TellerConnectOnFailure;
-  onEvent: null | TellerConnectOnEvent;
-  onExit: null | TellerConnectOnExit;
-  environment: "production" | "development" | "sandbox";
+  // Required options
   applicationId: string;
-  enrollmentId: null | string;
-  institution: null | string;
-  selectAccount: "disabled" | "single" | "multiple";
-  connectToken: null | string;
-  nonce: null | string;
-  appearance: null | "dark" | "light" | "system";
-  products: Array<"identity" | "verify" | "transactions">;
-  accountFilter: null | object;
-  [key: string]: any;
+  onSuccess: TellerConnectOnSuccess;
+
+  // Additional options
+  environment?: "sandbox" | "development" | "production";
+  institution?: string;
+  selectAccount?: "disabled" | "single" | "multiple";
+  enrollmentId?: string;
+  connectToken?: string;
+  nonce?: string;
+  onInit?: TellerConnectOnLoad;
+  onExit?: TellerConnectOnExit;
+  onFailure?: TellerConnectOnFailure;
+
+  // Undocumented options
+  appearance?: "dark" | "light" | "system";
+  products?: ("identity" | "verify" | "transactions")[];
+  accountFilter?: object;
+  onEvent?: TellerConnectOnEvent;
 }
 
 export interface TellerConnectInstance {
@@ -67,7 +62,7 @@ export interface TellerConnectInstance {
   destroy: () => void;
 }
 
-export interface TellerConnect extends TellerConnectManager {
+export interface TellerConnect extends TellerConnectInstance {
   setup: (config: TellerConnectOptions) => TellerConnectInstance;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -62,12 +62,6 @@ export interface TellerConnectOptions {
   [key: string]: any;
 }
 
-export type TellerConnectPropTypes = TellerConnectOptions & {
-  children: React.ReactNode;
-  className?: string;
-  style?: React.CSSProperties;
-};
-
 export interface TellerConnectInstance {
   open: () => void;
   destroy: () => void;

--- a/src/useTellerConnect.test.tsx
+++ b/src/useTellerConnect.test.tsx
@@ -41,8 +41,8 @@ describe('useTellerConnect', () => {
   beforeEach(() => {
     mockedUseScript.mockImplementation(() => ScriptLoadingState.LOADED);
     window.TellerConnect = {
-      setup: ({ onLoad }) => {
-        onLoad && onLoad();
+      setup: ({ onInit }) => {
+        onInit && onInit();
         return {
           create: jest.fn(),
           open: jest.fn(),
@@ -74,7 +74,9 @@ describe('useTellerConnect', () => {
   });
 
   it('should not be ready if applicationId is missing', async () => {
-    render(<HookComponent config={{ ...config, applicationId: null }} />);
+    // NOTE: Casting to any is necessary here because the TellerConnectOptions interface marks
+    //       applicationId as required
+    render(<HookComponent config={{ ...config, applicationId: undefined as any }} />);
     expect(screen.getByText(ReadyState.NOT_READY));
     expect(screen.getByText(ReadyState.NO_ERROR));
   });

--- a/src/useTellerConnect.ts
+++ b/src/useTellerConnect.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
 import useScript from 'react-script-hook';
 
-import { createTeller, TellerConnectManager } from './manager';
-import { TellerConnectOptions } from './types';
+import { createTeller } from './manager';
+import { TellerConnectInstance, TellerConnectOptions } from './types';
 
 const TC_JS = 'https://cdn.teller.io/connect/connect.js';
 
@@ -12,7 +12,7 @@ export const useTellerConnect = (options: TellerConnectOptions) => {
     checkForExisting: true,
   });
 
-  const [teller, setTeller] = useState<TellerConnectManager | null>(null);
+  const [teller, setTeller] = useState<TellerConnectInstance | null>(null);
   const [iframeLoaded, setIframeLoaded] = useState(false);
 
   useEffect(() => {


### PR DESCRIPTION
A rework of the existing type declarations to fix various errors:
1. The previous type declarations used `field: null | ...` instead of `field?: ...` to define optional fields
2. Using `React.HTMLProps<HTMLButtonElement>` on the `TellerConnect` component to provide better props IntelliSense
3. Rename `onLoad` method to `onInit` to match docs
4. Remove unnecessary `| string` and `[key: string]: any` from types
5. Remove unnecessary types