### PR TITLE
Documentation correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { useTellerConnect } from 'teller-connect-react';
 // ...
 
 const { open, ready } = useTellerConnect({
-  appId: "YOUR_APPLICATION_ID",
+  applicationId: "YOUR_APPLICATION_ID",
   onSuccess: (authorization) => {
     // Save your access token here
   },


### PR DESCRIPTION
`appId` does not work as a configuration key in the useTellerConnect hook