### PR TITLE
Correct Webpack configuration for case sensitive systems like Linux

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,13 +11,13 @@ module.exports = [
       'react': {
         commonjs: 'react',
         commonjs2: 'react',
-        amd: 'React',
+        amd: 'react',
         root: 'React'
       },
       'react-dom': {
         commonjs: 'react-dom',
         commonjs2: 'react-dom',
-        amd: 'ReactDOM',
+        amd: 'react-dom',
         root: 'ReactDOM'
       }
     },
@@ -46,13 +46,13 @@ module.exports = [
       'react': {
         commonjs: 'react',
         commonjs2: 'react',
-        amd: 'React',
+        amd: 'react',
         root: 'React'
       },
       'react-dom': {
         commonjs: 'react-dom',
         commonjs2: 'react-dom',
-        amd: 'ReactDOM',
+        amd: 'react-dom',
         root: 'ReactDOM'
       }
     },
@@ -82,13 +82,13 @@ module.exports = [
       'react': {
         commonjs: 'react',
         commonjs2: 'react',
-        amd: 'React',
+        amd: 'react',
         root: 'React'
       },
       'react-dom': {
         commonjs: 'react-dom',
         commonjs2: 'react-dom',
-        amd: 'ReactDOM',
+        amd: 'react-dom',
         root: 'ReactDOM'
       }
     },


### PR DESCRIPTION
The current build doesn't work on Linux, cant Resolve module 'React', it's supposed to be 'react'. Works on MacOS cause of case insensitivity but fails on Linux. Noticed this while working on the build server. 
Warning:
There are multiple modules with names that only differ in casing. This can lead to unexpected behavior when compiling on a filesystem with other case-semantic. Use equal casing. Compare these module identifiers:
node_modules/React/index.js
used by teller-connect-react/dist/teller-connect-react.umd.js
and
/node_modules/react/index.js
Used by 1267 module(s)