### PR TITLE
Fix possible infinite useEffect on options.products

### DIFF
--- a/src/useTellerConnect.ts
+++ b/src/useTellerConnect.ts
@@ -54,7 +54,7 @@ export const useTellerConnect = (options: TellerConnectOptions) => {
     options.enrollmentId,
     options.connectToken,
     // Array's ref could change, so we want to enforce value-comparison:
-    options.products ? JSON.stringify(options.products) : undefined,
+    (options.products || []).slice().sort().join(',')
   ]);
 
   const ready = teller != null && (!loading || iframeLoaded);

--- a/src/useTellerConnect.ts
+++ b/src/useTellerConnect.ts
@@ -53,7 +53,8 @@ export const useTellerConnect = (options: TellerConnectOptions) => {
     options.applicationId,
     options.enrollmentId,
     options.connectToken,
-    options.products,
+    // Array's ref could change, so we want to enforce value-comparison:
+    options.products ? JSON.stringify(options.products) : undefined,
   ]);
 
   const ready = teller != null && (!loading || iframeLoaded);

--- a/src/useTellerConnect.ts
+++ b/src/useTellerConnect.ts
@@ -15,6 +15,9 @@ export const useTellerConnect = (options: TellerConnectOptions) => {
   const [teller, setTeller] = useState<TellerConnectInstance | null>(null);
   const [iframeLoaded, setIframeLoaded] = useState(false);
 
+  // Array's ref could change, so we want to enforce value-comparison:
+  const productsString = (options.products || []).slice().sort().join(',');
+
   useEffect(() => {
     if (loading) {
       return;
@@ -53,8 +56,7 @@ export const useTellerConnect = (options: TellerConnectOptions) => {
     options.applicationId,
     options.enrollmentId,
     options.connectToken,
-    // Array's ref could change, so we want to enforce value-comparison:
-    (options.products || []).slice().sort().join(',')
+    productsString
   ]);
 
   const ready = teller != null && (!loading || iframeLoaded);


### PR DESCRIPTION
Fixes https://github.com/tellerhq/teller-connect-react/issues/15

> there's a bug where the useTellerConnect hook is passing options.products to useEffect which would only work if the array of products is instantiated outside of the component rendering. If the array is defined as a literal within the render method, then it is re-instantiated every render and that causes an infinite loop

## Infinite loop sequence

- Component renders, creating a new array for products (in JS an array literal creates a new ref on every render)
- The `useEffect` in `useTellerConnect` detects that `options.products` has a new ref
- The effect runs again, recreating the Teller instance
- This causes a state update (via `setTeller(next)`)
- State update triggers a re-render
- Re-render creates a new array for products
- The cycle repeats infinitely

## Solution

Serialize products dependency, as it's just a shallow list with few known values.

Some context: https://github.com/facebook/react/issues/14476#issuecomment-471199055