### PR TITLE
Allow React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-script-hook": "^1.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || 17 - 18",
-    "react-dom": "^16.8.6 || 17 - 18"
+    "react": "^16.8.6 || 17 - 19",
+    "react-dom": "^16.8.6 || 17 - 19"
   }
 }


### PR DESCRIPTION
It works with React 19. Tested with a new Vite app (both `useTellerConnect` and `<TellerConnect />`)