### PR TITLE
Fix code example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ your application.
 ```tsx
 import { TellerConnect } from "teller-connect-react";
 
-const App extends React.Component {
+class App extends React.Component {
   // ...
   render() {
     return (


### PR DESCRIPTION
The code example under "Using the pre-built component instead of the userTellerConnect hook" was using `const` where it should have be been using `class`.